### PR TITLE
fix: change python version to match requirements

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -16,10 +16,10 @@ jobs:
         ref: ${{ env.DEFAULT_BRANCH }}
         fetch-depth: 0
         token: ${{ secrets.SERVICE_TOKEN }}
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: | 
         python -m pip install -e .[dev] --no-cache-dir


### PR DESCRIPTION
@alejoe91 for release - this was failing because it was trying to install python 3.8, but aind-nwb-utils requires >=3.10. I set this to 3.10 - that seem ok?