### PR TITLE
Fix experimenters name

### DIFF
--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -484,7 +484,6 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
 
     data_description = metadata_map[data_path / "data_description.json"]
     subject_metadata = metadata_map[data_path / "subject.json"]
-    procedures_metadata = metadata_map[data_path / "procedures.json"]
     processing_metadata = metadata_map[data_path / "processing.json"]
     session_metadata = metadata_map[session_or_acquisition_path]
 
@@ -494,12 +493,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
     )
 
     experimenters = [
-        procedure.get("experimenter_full_name")
-        for procedure in procedures_metadata.get("subject_procedures", [])
-    ]
-    experimenters += [
-        investigator.get("name", "No Experimenter Name")
-        for investigator in data_description.get("investigators", [])
+        ", ".join(session_metadata.get("experimenter_full_name"), "") or "Unknown"
     ]
 
     generation_code = [

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -287,14 +287,16 @@ def merge_nwb_attribute(
             if main_attr != attr:
                 logger.warning(
                     f"Attribute mismatch for '{field_name}': "
-                    f"main={main_attr!r}, sub={attr!r}. Using main NWB file's value."
+                    f"main={main_attr!r}, sub={attr!r}. Using main NWB \
+                        file's value."
                 )
         elif isinstance(attr, zarr.core.Array):
             main_attr = getattr(main_io, field_name, None)
             if main_attr is not None and list(main_attr) != list(attr):
                 logger.warning(
                     f"Attribute mismatch for '{field_name}': "
-                    f"main={list(main_attr)!r}, sub={list(attr)!r}. Using main NWB file's value."
+                    f"main={list(main_attr)!r}, sub={list(attr)!r}. \
+                        Using main NWB file's value."
                 )
         elif isinstance(attr, dict) or hasattr(attr, "keys"):
             _handle_dict_like_attributes(main_io, attr, field_name)

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -525,7 +525,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         institution=data_description["institution"].get("name", None),
         subject=nwb_subject,
         session_id=data_description["name"],
-        experimenter=str(experimenters),
+        experimenter=experimenters,
         lab=data_description.get("group", ""),
     )
 

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -523,7 +523,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         institution=data_description["institution"].get("name", None),
         subject=nwb_subject,
         session_id=data_description["name"],
-        experimenter=experimenters,
+        experimenter="Test make sure to remove",
         lab=data_description.get("group", ""),
     )
 

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -493,7 +493,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
     )
 
     experimenters = [
-        ", ".join(session_metadata.get("experimenter_full_name"), "") or "Unknown"
+        ", ".join(session_metadata.get("experimenter_full_name", "")) or "Unknown"
     ]
 
     generation_code = [

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -491,10 +491,6 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
     session_start_date_time = _get_session_start_date_time(
         data_description["creation_time"]
     )
-
-    experimenters = [
-        ", ".join(session_metadata.get("experimenter_full_name", "")) or "Unknown"
-    ]
     
     generation_code = [
         process.get("code")
@@ -525,7 +521,6 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         institution=data_description["institution"].get("name", None),
         subject=nwb_subject,
         session_id=data_description["name"],
-        experimenter=experimenters,
         lab=data_description.get("group", ""),
     )
 

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -492,9 +492,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         data_description["creation_time"]
     )
 
-    experimenters = [
-        ", ".join(session_metadata.get("experimenter_full_name", "")) or "Unknown"
-    ]
+    experimenters = ", ".join(session_metadata.get("experimenter_full_name", "")) or "Unknown"
 
     generation_code = [
         process.get("code")

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -543,10 +543,10 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         session_description=experiment_description,
         identifier=str(uuid.uuid4()),
         session_start_time=session_start_date_time,
-        experimenter=str(experimenters),
         institution=data_description["institution"].get("name", None),
         subject=nwb_subject,
         session_id=data_description["name"],
+        experimenter=str(experimenters),
         lab=data_description.get("group", ""),
     )
 

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -492,8 +492,10 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         data_description["creation_time"]
     )
 
-    experimenters = ", ".join(session_metadata.get("experimenter_full_name", "")) or "Unknown"
-
+    experimenters = [
+        ", ".join(session_metadata.get("experimenter_full_name", "")) or "Unknown"
+    ]
+    
     generation_code = [
         process.get("code")
         for process in processing_metadata.get("processing_pipeline", {}).get(
@@ -523,7 +525,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         institution=data_description["institution"].get("name", None),
         subject=nwb_subject,
         session_id=data_description["name"],
-        experimenter="Test make sure to remove",
+        experimenter=experimenters,
         lab=data_description.get("group", ""),
     )
 

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -491,7 +491,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
     session_start_date_time = _get_session_start_date_time(
         data_description["creation_time"]
     )
-    
+
     generation_code = [
         process.get("code")
         for process in processing_metadata.get("processing_pipeline", {}).get(

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Iterable, Union
 
 import numpy as np
+import zarr
 import pynwb
 import pytz
 from hdmf_zarr import NWBZarrIO
@@ -281,6 +282,20 @@ def merge_nwb_attribute(
             _handle_time_intervals(main_io, attr, field_name)
         elif isinstance(attr, EventsTable):
             _handle_events_table(main_io, attr, field_name)
+        elif isinstance(attr, tuple):
+            main_attr = getattr(main_io, field_name, None)
+            if main_attr != attr:
+                logger.warning(
+                    f"Attribute mismatch for '{field_name}': "
+                    f"main={main_attr!r}, sub={attr!r}. Using main NWB file's value."
+                )
+        elif isinstance(attr, zarr.core.Array):
+            main_attr = getattr(main_io, field_name, None)
+            if main_attr is not None and list(main_attr) != list(attr):
+                logger.warning(
+                    f"Attribute mismatch for '{field_name}': "
+                    f"main={list(main_attr)!r}, sub={list(attr)!r}. Using main NWB file's value."
+                )
         elif isinstance(attr, dict) or hasattr(attr, "keys"):
             _handle_dict_like_attributes(main_io, attr, field_name)
         else:

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -499,6 +499,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
 
     data_description = metadata_map[data_path / "data_description.json"]
     subject_metadata = metadata_map[data_path / "subject.json"]
+    procedures_metadata = metadata_map[data_path / "procedures.json"]
     processing_metadata = metadata_map[data_path / "processing.json"]
     session_metadata = metadata_map[session_or_acquisition_path]
 
@@ -506,6 +507,15 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
     session_start_date_time = _get_session_start_date_time(
         data_description["creation_time"]
     )
+
+    experimenters = [
+        procedure.get("experimenter_full_name")
+        for procedure in procedures_metadata.get("subject_procedures", [])
+    ]
+    experimenters += [
+        investigator.get("name", "No Experimenter Name")
+        for investigator in data_description.get("investigators", [])
+    ]
 
     generation_code = [
         process.get("code")
@@ -533,6 +543,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         session_description=experiment_description,
         identifier=str(uuid.uuid4()),
         session_start_time=session_start_date_time,
+        experimenter=str(experimenters),
         institution=data_description["institution"].get("name", None),
         subject=nwb_subject,
         session_id=data_description["name"],


### PR DESCRIPTION
tuple branch in merge_nwb_attribute — handles fields like experimenter that PyNWB normalizes to tuples and logs a warning if the sub file's value differs from main's, then keeps main's value.

zarr.core.Array branch in merge_nwb_attribute — handles fields like was_generated_by that come back as Zarr arrays when read from a .nwb.zarr file. Same behavior: warn on mismatch, keep main's value.