### PR TITLE
refactor: remove procedures.json from metadata map

### DIFF
--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -435,7 +435,9 @@ def open_metadata_jsons(
         if path.exists():
             metadata_map[path] = open_metadata_json(path)
         else:
-            raise ValueError("Missing metadata file: ")
+            raise ValueError(
+                f"Missing metadata file: {path.stem}"
+            )
 
     return metadata_map
 

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -493,7 +493,6 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
         [
             data_path / "data_description.json",
             data_path / "subject.json",
-            data_path / "procedures.json",
             data_path / "processing.json",
             session_or_acquisition_path,
         ]


### PR DESCRIPTION
The procedures file is sometimes missing for sessions with no procedures or a custom procedure that was performed and is not in the NSB sharepoint tracking document.

This PR removes fetching it, as it was not used anywhere downstream and allows for the rest of the creation of the base nwb file to proceed as normal