### PR TITLE
fix: error with pynwb 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'pynwb',
-    'ndx-events',
+    'pynwb>=4.0.0',
     'hdmf-zarr',
     'xarray',
     'pytz',

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -14,12 +14,9 @@ import zarr
 import pynwb
 import pytz
 from hdmf_zarr import NWBZarrIO
-from ndx_events import (
-    EventsTable,
-    NdxEventsNWBFile,
-)
 from packaging.version import parse
-from pynwb import NWBHDF5IO, TimeSeries
+from pynwb import NWBHDF5IO, NWBFile, TimeSeries
+from pynwb.event import EventsTable
 from pynwb.base import VectorData
 from pynwb.file import Device, Subject
 
@@ -531,7 +528,7 @@ def create_base_nwb_file(data_path: Path) -> pynwb.NWBFile:
             " Experiment includes " + ", ".join(modalities) + " modalities."
         )
 
-    nwb_file = NdxEventsNWBFile(
+    nwb_file = NWBFile(
         session_description=experiment_description,
         identifier=str(uuid.uuid4()),
         session_start_time=session_start_date_time,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, create_autospec
 
 import numpy as np
-from ndx_events import EventsTable
 from pynwb import NWBFile, TimeSeries
+from pynwb.event import EventsTable
 from pynwb.base import (  # example NWB container
     Images,
     ProcessingModule,


### PR DESCRIPTION
Attempts to close #51. The ndx-events extension was merged into core NWB in version 4.0. The dependencies listed both pynwb and ndx-events, which I think was causing the collision error seen in #51 (NdxEventsNWBFile.__init__: The following names are duplicated: ['events']).

This PR:

- Sets the lower bound on pynwb to >=4.0.0
- Removes the ndx-events dependency
- Switches EventsTable import to pynwb.event and uses core pynwb.NWBFile instead of NdxEventsNWBFile

Events are now part of core, and the existing tests pass (including the combine/merge and events-table tests). There might be better approaches then pinning the lower bound.

NOTE: With this change, downstream environments that read in nwbs generated after this change will need pynwb>=4.0.0. Reading historical files (written with the old ndx-events namespace) still requires ndx-events installed alongside pynwb.