### PR TITLE
62 add imaging data

### DIFF
--- a/src/aind_nwb_utils/nwb.py
+++ b/src/aind_nwb_utils/nwb.py
@@ -5,8 +5,9 @@ from typing import Union
 from pathlib import Path
 
 import pynwb
+from hdmf.build import BuildManager, TypeMap
 from hdmf_zarr import NWBZarrIO
-from pynwb import NWBHDF5IO
+from pynwb import NWBHDF5IO, get_type_map
 import logging
 
 from aind_nwb_utils.nwb_io import determine_io
@@ -73,6 +74,47 @@ class NWBCombineIO:
         self._stack: ExitStack | None = None
         self._main_io: Union[NWBHDF5IO, NWBZarrIO] | None = None
         self._nwb: pynwb.NWBFile | None = None
+        self._type_map: TypeMap | None = None
+
+    def _build_type_map(self) -> TypeMap:
+        """Build a single TypeMap spanning every input file's namespaces.
+
+        Each file caches the namespaces it was written with. Reading a file
+        with its own cached namespaces gives each IO handle an isolated
+        TypeMap that only knows that file's extensions. Because
+        :meth:`write` exports through the *main* IO's build manager, any
+        container coming from a sub file whose extension is unknown to the
+        main IO gets mapped to the nearest base type it does know: an
+        ``ndx-hed`` ``HedLabMetaData`` silently degrades to a plain
+        ``LabMetaData`` and every extension-specific attribute is dropped.
+
+        Loading all inputs into one TypeMap and sharing it across every
+        handle keeps extension types (and their attributes and cached
+        specs) intact through the merge and the export.
+
+        Returns
+        -------
+        TypeMap
+            A TypeMap with the core namespaces plus every extension
+            namespace cached in the main or sub files.
+        """
+        type_map = get_type_map()
+        for nwb_fp in [self._main_nwb_fp, *self._sub_nwb_paths]:
+            io_class = determine_io(nwb_fp)
+            try:
+                io_class.load_namespaces(type_map, path=str(nwb_fp))
+            except Exception as e:
+                # A file without cached specs is still readable with the
+                # namespaces already loaded, so this is not fatal.
+                logger.warning(
+                    f"Could not load cached namespaces from {nwb_fp}: {e}"
+                )
+
+        logger.info(
+            "Combining with namespaces: "
+            f"{sorted(type_map.namespace_catalog.namespaces)}"
+        )
+        return type_map
 
     def _open(self) -> tuple[pynwb.NWBFile, Union[NWBHDF5IO, NWBZarrIO]]:
         """Open all IO handles and perform the merge."""
@@ -80,18 +122,30 @@ class NWBCombineIO:
             return self._nwb, self._main_io
 
         self._stack = ExitStack()
+        self._type_map = self._build_type_map()
         main_io_class = determine_io(self._main_nwb_fp)
 
         logger.info(self._main_nwb_fp)
         self._main_io = self._stack.enter_context(
-            main_io_class(self._main_nwb_fp, "r")
+            main_io_class(
+                self._main_nwb_fp,
+                "r",
+                manager=BuildManager(self._type_map),
+            )
         )
         self._nwb = self._main_io.read()
 
         for sub_nwb_fp in self._sub_nwb_paths:
             logger.info(sub_nwb_fp)
             sub_io_class = determine_io(sub_nwb_fp)
-            sub_io = self._stack.enter_context(sub_io_class(sub_nwb_fp, "r"))
+            # Each handle needs its own BuildManager (they cache
+            # builder/container pairs per file) but they must share the
+            # TypeMap so containers are interchangeable between them.
+            sub_io = self._stack.enter_context(
+                sub_io_class(
+                    sub_nwb_fp, "r", manager=BuildManager(self._type_map)
+                )
+            )
             sub_nwb = sub_io.read()
             self._nwb = merge_nwb_attribute(self._nwb, sub_nwb)
 
@@ -135,7 +189,12 @@ class NWBCombineIO:
             )
 
         logger.info(f"Writing to disk at {output_path}")
-        with save_io(output_path, "w") as out_io:
+        # The destination handle caches the spec from its own manager, so it
+        # needs the combined TypeMap too or the sub files' extension
+        # namespaces would be missing from the output's /specifications.
+        with save_io(
+            output_path, "w", manager=BuildManager(self._type_map)
+        ) as out_io:
             out_io.export(
                 src_io=self._main_io, write_args=dict(link_data=False)
             )

--- a/src/aind_nwb_utils/utils.py
+++ b/src/aind_nwb_utils/utils.py
@@ -24,9 +24,40 @@ from pynwb.file import Device, Subject
 logger = logging.getLogger(__name__)
 
 
+# Maps an NWBFile field name to the public method that adds a container to
+# it. Derived from ``NWBFile.__clsconf__``; kept explicit so the public
+# (validating) adders are used rather than the private internal ones.
+NWB_FIELD_ADDERS = {
+    "acquisition": "add_acquisition",
+    "analysis": "add_analysis",
+    "device_models": "add_device_model",
+    "devices": "add_device",
+    "electrode_groups": "add_electrode_group",
+    "events": "add_events_table",
+    "icephys_electrodes": "add_icephys_electrode",
+    "imaging_planes": "add_imaging_plane",
+    "intervals": "add_time_intervals",
+    "lab_meta_data": "add_lab_meta_data",
+    "ogen_sites": "add_ogen_site",
+    "processing": "add_processing_module",
+    "scratch": "add_scratch",
+    "stimulus": "add_stimulus",
+    "stimulus_template": "add_stimulus_template",
+}
+
+# TimeIntervals-valued NWBFile fields that are also exposed through the
+# ``intervals`` dict. Merging them through ``intervals`` is what puts them
+# at /intervals/<name> in the output.
+TIME_INTERVAL_FIELDS = ("intervals", "trials", "epochs", "invalid_times")
+
+
 def is_non_mergeable(attr: Any):
     """
-    Check if an attribute is not suitable for merging into the NWB file.
+    Check if an attribute is a scalar/metadata value rather than a container.
+
+    These are not merged element-wise. The main file's value wins when both
+    files have one; see :func:`_handle_scalar_attribute` for how a value
+    missing from the main file is filled in from a sub file.
 
     Parameters
     ----------
@@ -66,8 +97,11 @@ def cast_timeseries_if_needed(ts_obj):
     ts_obj: TimeSeries or original object
         The original TimeSeries object or a new one with casted data.
     """
-    if not isinstance(ts_obj, TimeSeries):
-        return ts_obj  # Only handle TimeSeries
+    # Only rebuild plain TimeSeries. Rebuilding a subclass as a TimeSeries
+    # would discard its neurodata_type and every extension-specific field,
+    # so extension time series are passed through untouched.
+    if type(ts_obj) is not TimeSeries:
+        return ts_obj
 
     data = ts_obj.data
     if hasattr(data, "dtype") and data.dtype in [np.float64, np.int64]:
@@ -82,12 +116,14 @@ def cast_timeseries_if_needed(ts_obj):
                 rate=ts_obj.rate,
                 conversion=ts_obj.conversion,
                 resolution=ts_obj.resolution,
+                offset=ts_obj.offset,
                 starting_time=ts_obj.starting_time,
                 timestamps=ts_obj.timestamps,
                 description=ts_obj.description,
                 comments=ts_obj.comments,
                 control=ts_obj.control,
                 control_description=ts_obj.control_description,
+                continuity=ts_obj.continuity,
             )
         except Exception as e:
             logger.exception(
@@ -140,23 +176,30 @@ def add_data(
     obj : Any
         The NWB container object to add.
     """
+    existing = getattr(main_io, field, None) or {}
+    if name in existing:
+        logger.info(
+            f"'{name}' already present in {field} of the main NWB file; "
+            "keeping the main file's copy"
+        )
+        return
+
+    adder_name = NWB_FIELD_ADDERS.get(field)
+    if adder_name is None:
+        raise ValueError(f"Unknown attribute type: {field}")
+
+    adder = getattr(main_io, adder_name, None)
+    if adder is None:
+        raise ValueError(
+            f"Cannot merge '{name}' into '{field}': the main NWB file "
+            f"({type(main_io).__name__}) has no {adder_name} method."
+        )
+
+    # Reparent only once we know the object is actually going to be added,
+    # otherwise a skipped object is left detached from its source file.
     obj.reset_parent()
     obj.parent = main_io
-    existing = getattr(main_io, field, {})
-    if name in existing:
-        return
-    if field == "acquisition":
-        main_io.add_acquisition(obj)
-    elif field == "processing":
-        main_io.add_processing_module(obj)
-    elif field == "analysis":
-        main_io.add_analysis(obj)
-    elif field == "intervals":
-        main_io.add_time_intervals(obj)
-    elif field == "events":
-        main_io.add_events_table(obj)
-    else:
-        raise ValueError(f"Unknown attribute type: {field}")
+    adder(obj)
 
 
 def _handle_time_intervals(
@@ -179,10 +222,17 @@ def _handle_time_intervals(
     None
         Merges the TimeIntervals into main_io in place.
     """
-    attr.reset_parent()
-    attr.parent = main_io
-    if field_name == "intervals":
-        main_io.add_time_intervals(attr)
+    if field_name not in TIME_INTERVAL_FIELDS:
+        logger.warning(
+            f"Merging TimeIntervals from unexpected field '{field_name}' "
+            "into intervals"
+        )
+
+    # ``trials``, ``epochs`` and ``invalid_times`` are separate NWBFile
+    # fields but all live under /intervals/<name>, so they are merged
+    # through ``intervals``. Previously only field_name == "intervals" was
+    # added and the rest were reparented and silently dropped.
+    add_data(main_io, "intervals", attr.name, attr)
 
 
 def _handle_events_table(
@@ -205,16 +255,19 @@ def _handle_events_table(
     None
         Merges the EventsTable into main_io in place.
     """
-    if field_name in main_io.events:
+    # ``events`` is keyed by table name, not by the NWBFile field name.
+    existing_tables = getattr(main_io, "events", None) or {}
+    if attr.name in existing_tables:
         # Merge the columns safely
-        existing_table = main_io.events[field_name]
-        for col_name in attr.columns:
-            if col_name not in existing_table.columns:
-                existing_table.add_column(attr.columns[col_name])
+        existing_table = existing_tables[attr.name]
+        existing_names = {col.name for col in existing_table.columns}
+        for column in attr.columns:
+            if column.name not in existing_names:
+                existing_table.add_column(column)
             else:
-                existing_table[col_name].data.extend(attr[col_name].data)
+                existing_table[column.name].data.extend(column.data)
     else:
-        main_io.add_events_table(attr)
+        add_data(main_io, "events", attr.name, attr)
 
 
 def _handle_dict_like_attributes(
@@ -241,14 +294,93 @@ def _handle_dict_like_attributes(
         data = cast_timeseries_if_needed(data)
         data = cast_vectordata_if_needed(data)
 
-        if field_name == "devices":
-            if name not in main_io.devices:
-                data.reset_parent()
-                data.parent = main_io
-                main_io.add_device(data)
-            return
-
+        # NOTE: this used to ``return`` after the first device, which dropped
+        # every remaining device in the sub file. add_data already skips
+        # names the main file has, so devices need no special case.
         add_data(main_io, field_name, name, data)
+
+
+def _handle_scalar_attribute(
+    main_io: Union[NWBHDF5IO, NWBZarrIO], attr: Any, field_name: str
+) -> None:
+    """
+    Handle a scalar/metadata attribute during NWB merge.
+
+    The main file's value always wins when it has one. When the main file is
+    missing the field entirely the sub file's value is copied over instead of
+    being discarded, so session metadata (``institution``, ``experimenter``,
+    ``was_generated_by``, ``subject`` ...) present in only one input still
+    reaches the combined file.
+
+    Parameters
+    ----------
+    main_io : Union[NWBHDF5IO, NWBZarrIO]
+        The destination NWB file IO object.
+    attr : Any
+        The scalar attribute from the sub file.
+    field_name : str
+        The name of the field being processed.
+
+    Returns
+    -------
+    None
+        Updates main_io in place.
+    """
+    main_attr = getattr(main_io, field_name, None)
+
+    if main_attr is not None:
+        if _scalar_values_differ(main_attr, attr):
+            logger.warning(
+                f"Attribute mismatch for '{field_name}': "
+                f"main={main_attr!r}, sub={attr!r}. "
+                "Using main NWB file's value."
+            )
+        return
+
+    if attr is None:
+        return
+
+    if isinstance(attr, pynwb.core.NWBContainer):
+        attr.reset_parent()
+
+    try:
+        setattr(main_io, field_name, attr)
+    except (AttributeError, TypeError) as e:
+        logger.warning(
+            f"Could not copy '{field_name}' from the sub NWB file: {e}"
+        )
+        return
+
+    logger.info(f"Copied '{field_name}' from sub NWB file into the merge")
+
+
+def _scalar_values_differ(main_attr: Any, sub_attr: Any) -> bool:
+    """
+    Compare two scalar attribute values, tolerating array-like containers.
+
+    Parameters
+    ----------
+    main_attr : Any
+        The value from the main NWB file.
+    sub_attr : Any
+        The value from the sub NWB file.
+
+    Returns
+    -------
+    bool
+        True when the two values are not equivalent.
+    """
+    if isinstance(main_attr, (zarr.core.Array, np.ndarray)) or isinstance(
+        sub_attr, (zarr.core.Array, np.ndarray)
+    ):
+        try:
+            return list(main_attr) != list(sub_attr)
+        except Exception:
+            return True
+    try:
+        return bool(main_attr != sub_attr)
+    except Exception:
+        return True
 
 
 def merge_nwb_attribute(
@@ -274,28 +406,13 @@ def merge_nwb_attribute(
         attr = getattr(sub_io, field_name)
 
         if is_non_mergeable(attr):
-            continue
-
-        if isinstance(attr, pynwb.epoch.TimeIntervals):
+            _handle_scalar_attribute(main_io, attr, field_name)
+        elif isinstance(attr, pynwb.epoch.TimeIntervals):
             _handle_time_intervals(main_io, attr, field_name)
         elif isinstance(attr, EventsTable):
             _handle_events_table(main_io, attr, field_name)
-        elif isinstance(attr, tuple):
-            main_attr = getattr(main_io, field_name, None)
-            if main_attr != attr:
-                logger.warning(
-                    f"Attribute mismatch for '{field_name}': "
-                    f"main={main_attr!r}, sub={attr!r}. Using main NWB \
-                        file's value."
-                )
-        elif isinstance(attr, zarr.core.Array):
-            main_attr = getattr(main_io, field_name, None)
-            if main_attr is not None and list(main_attr) != list(attr):
-                logger.warning(
-                    f"Attribute mismatch for '{field_name}': "
-                    f"main={list(main_attr)!r}, sub={list(attr)!r}. \
-                        Using main NWB file's value."
-                )
+        elif isinstance(attr, (tuple, zarr.core.Array, np.ndarray)):
+            _handle_scalar_attribute(main_io, attr, field_name)
         elif isinstance(attr, dict) or hasattr(attr, "keys"):
             _handle_dict_like_attributes(main_io, attr, field_name)
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -462,6 +462,8 @@ class TestUtils(unittest.TestCase):
 
     def test_create_nwb_base_file(self):
         """Test create_nwb_base_file with ADS 1.x (session.json)"""
+        import os
+
         with open(Path("tests/resources/data_description.json")) as f:
             data_description = json.load(f)
         with open(Path("tests/resources/session.json")) as f:
@@ -475,14 +477,18 @@ class TestUtils(unittest.TestCase):
         self.assertIn(project_name, nwb_file_base.session_description)
         self.assertIn(session_type, nwb_file_base.session_description)
 
-        with tempfile.NamedTemporaryFile(suffix=".nwb") as nwb_file:
-            with NWBHDF5IO(nwb_file.name, "w") as nwb_io:
+        fd, nwb_path = tempfile.mkstemp(suffix=".nwb")
+        os.close(fd)
+        try:
+            with NWBHDF5IO(nwb_path, "w") as nwb_io:
                 nwb_io.write(nwb_file_base)
-            with h5py.File(nwb_file.name, "r") as h5_file:
+            with h5py.File(nwb_path, "r") as h5_file:
                 self.assertEqual(
                     h5_file["general/was_generated_by"].shape,
                     (1, 2),
                 )
+        finally:
+            os.unlink(nwb_path)
 
     @patch(
         "aind_nwb_utils.utils.package_version",
@@ -594,7 +600,7 @@ class TestUtils(unittest.TestCase):
         mock_main_io.reset_mock()
         mock_time_intervals.reset_mock()
 
-        # Test with field_name != "intervals"
+        # Test with field_name != "intervals" — still routed through intervals
         _handle_time_intervals(
             mock_main_io, mock_time_intervals, "other_field"
         )
@@ -603,7 +609,9 @@ class TestUtils(unittest.TestCase):
         mock_time_intervals.reset_parent.assert_called_once()
         self.assertEqual(mock_time_intervals.parent, mock_main_io)
 
-        mock_main_io.add_time_intervals.assert_not_called()
+        mock_main_io.add_time_intervals.assert_called_once_with(
+            mock_time_intervals
+        )
 
     def test_handle_time_intervals_with_real_objects(self):
         """Test _handle_time_intervals with real NWB objects"""
@@ -656,19 +664,19 @@ class TestUtils(unittest.TestCase):
         # Create a mock NWB file IO object
         mock_main_io = MagicMock()
 
-        # Create mock existing events table
+        # Create mock existing events table with a column object
+        mock_existing_col = MagicMock()
+        mock_existing_col.name = "existing_col"
         mock_existing_table = MagicMock()
-        mock_existing_table.columns = ["existing_col"]
+        mock_existing_table.columns = [mock_existing_col]
         mock_main_io.events = {"test_events": mock_existing_table}
 
-        # Create a mock EventsTable with new columns
+        # Create a mock EventsTable with a new column object
+        mock_new_column = MagicMock()
+        mock_new_column.name = "new_col"
         mock_new_events_table = MagicMock(spec=EventsTable)
         mock_new_events_table.name = "test_events"
-        mock_new_events_table.columns = ["new_col"]
-
-        # Mock the column objects
-        mock_new_column = MagicMock()
-        mock_new_events_table.columns = {"new_col": mock_new_column}
+        mock_new_events_table.columns = [mock_new_column]
 
         # Test merging with existing table
         _handle_events_table(
@@ -683,27 +691,25 @@ class TestUtils(unittest.TestCase):
         # Create a mock NWB file IO object
         mock_main_io = MagicMock()
 
-        # Create mock existing events table with existing column
-        mock_existing_table = MagicMock()
+        # Create mock existing events table with a column object
         mock_existing_column = MagicMock()
+        mock_existing_column.name = "shared_col"
         mock_existing_column.data = MagicMock()  # Mock the data object itself
         mock_existing_column.data.extend = (
             MagicMock()
         )  # Mock the extend method
-        mock_existing_table.columns = ["shared_col"]
+        mock_existing_table = MagicMock()
+        mock_existing_table.columns = [mock_existing_column]
         mock_existing_table.__getitem__.return_value = mock_existing_column
         mock_main_io.events = {"test_events": mock_existing_table}
 
         # Create a mock EventsTable with same column name
+        mock_new_column = MagicMock()
+        mock_new_column.name = "shared_col"
+        mock_new_column.data = [4, 5, 6]
         mock_new_events_table = MagicMock(spec=EventsTable)
         mock_new_events_table.name = "test_events"
-        mock_new_events_table.columns = ["shared_col"]
-
-        # Mock the new column data
-        mock_new_column = MagicMock()
-        mock_new_column.data = [4, 5, 6]
-        mock_new_events_table.__getitem__.return_value = mock_new_column
-        mock_new_events_table.columns = {"shared_col": mock_new_column}
+        mock_new_events_table.columns = [mock_new_column]
 
         # Test merging with existing table
         _handle_events_table(
@@ -724,14 +730,16 @@ class TestUtils(unittest.TestCase):
         # Create a mock NWB file IO object
         mock_main_io = MagicMock()
 
-        # Create mock existing events table
-        mock_existing_table = MagicMock()
+        # Create mock existing events table with a column object
+        mock_existing_col_obj = MagicMock()
+        mock_existing_col_obj.name = "existing_col"
         mock_existing_column = MagicMock()
         mock_existing_column.data = MagicMock()  # Mock the data object itself
         mock_existing_column.data.extend = (
             MagicMock()
         )  # Mock the extend method
-        mock_existing_table.columns = ["existing_col"]
+        mock_existing_table = MagicMock()
+        mock_existing_table.columns = [mock_existing_col_obj]
         mock_existing_table.__getitem__.return_value = mock_existing_column
         mock_main_io.events = {"test_events": mock_existing_table}
 
@@ -739,23 +747,16 @@ class TestUtils(unittest.TestCase):
         mock_new_events_table = MagicMock(spec=EventsTable)
         mock_new_events_table.name = "test_events"
 
-        # Mock columns
+        # Mock columns as a list of column objects with .name
         mock_existing_column_new_data = MagicMock()
+        mock_existing_column_new_data.name = "existing_col"
         mock_existing_column_new_data.data = [4, 5, 6]
         mock_new_column = MagicMock()
-
-        # Setup the columns dictionary
-        mock_new_events_table.columns = {
-            "existing_col": mock_existing_column_new_data,
-            "new_col": mock_new_column,
-        }
-
-        # Mock __getitem__ to return appropriate column
-        def mock_getitem(key):
-            """Mock __getitem__ method for EventsTable."""
-            return mock_new_events_table.columns[key]
-
-        mock_new_events_table.__getitem__.side_effect = mock_getitem
+        mock_new_column.name = "new_col"
+        mock_new_events_table.columns = [
+            mock_existing_column_new_data,
+            mock_new_column,
+        ]
 
         # Test merging with existing table
         _handle_events_table(


### PR DESCRIPTION
## Summary

Two refactors that fix silent data loss when merging NWB files with NWB extensions.

### Fix: prevent extension types from being silently downgraded during merge (`nwb.py`)

When combining multiple NWB files, each file's cached namespace specs were being loaded into isolated `TypeMap` instances per IO handle. Any extension type from a sub-file (e.g. `ndx-hed`'s `HedLabMetaData`) was unknown to the main file's build manager and silently downgraded to its nearest base type (`LabMetaData`), losing all extension-specific attributes on export.

Now `NWBCombineIO._build_type_map()` builds a single shared `TypeMap` from the cached namespaces of all input files, then passes a `BuildManager` backed by that map to every IO handle — including the output handle — so extension types survive the merge intact.

### Refactor: use public NWBFile adder methods for merging containers (`utils.py`)

- **`add_data`** now dispatches through a `NWB_FIELD_ADDERS` lookup table instead of a hard-coded `if/elif` chain, adding support for `imaging_planes`, `electrode_groups`, `ogen_sites`, `icephys_electrodes`, `lab_meta_data`, `scratch`, `stimulus`, `stimulus_template`, and `device_models`. Reparenting is now deferred until the object is confirmed to be new (so skipped objects aren't left detached).
- **`_handle_time_intervals`** now correctly merges `trials`, `epochs`, and `invalid_times` — previously only `field_name == "intervals"` was routed to `add_time_intervals`; the other three were reparented and silently dropped.
- **`_handle_events_table`** duplicate detection is now keyed on `attr.name` (the table name) rather than `field_name` (the NWBFile field), fixing incorrect deduplication. Column iteration now uses column objects directly.
- **`_handle_dict_like_attributes`** removes the early `return` after the first device, which was causing all subsequent devices in a sub-file to be dropped.
- **`cast_timeseries_if_needed`** now uses `type(ts_obj) is not TimeSeries` instead of `not isinstance(...)`, so TimeSeries subclasses are passed through untouched rather than being rebuilt as plain `TimeSeries` and losing their extension-specific fields. The rebuilt object now also carries `offset` and `continuity`.
- **`_handle_scalar_attribute`** and **`_scalar_values_differ`** are new helpers. Non-mergeable scalar fields (previously silently skipped) are now filled into the main file from the sub-file when the main file's field is `None`, so metadata like `institution` or `experimenter` present in only one input still reaches the combined output.


*Generated with [Claude Code](https://claude.ai/code)*
